### PR TITLE
restore split phone auth validation

### DIFF
--- a/src/modules/auth/application/services/authentication.service.spec.ts
+++ b/src/modules/auth/application/services/authentication.service.spec.ts
@@ -118,6 +118,8 @@ describe('AuthenticationService', () => {
       phone: '1234567890',
       countryCode: '+1',
       password: 'Password123!',
+      firstName: 'Test',
+      lastName: 'User',
       name: 'Test User',
       role: 'CUSTOMER',
     };
@@ -243,7 +245,7 @@ describe('AuthenticationService', () => {
 
     it('should refresh token successfully', async () => {
       userRepository.findByRefreshToken.mockResolvedValue(mockUser);
-      userManagementService.validateTokenRefreshEligibility.mockResolvedValue(true);
+      userManagementService.validateTokenRefreshEligibility.mockImplementation(() => undefined);
       jwtService.sign.mockReturnValueOnce(mockTokens.accessToken).mockReturnValueOnce(mockTokens.refreshToken);
       userRepository.save.mockResolvedValue(mockUser);
       mockUser.addRefreshToken = jest.fn();

--- a/src/modules/auth/application/services/otp-security.adapter.ts
+++ b/src/modules/auth/application/services/otp-security.adapter.ts
@@ -48,10 +48,9 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
   async generateRegistrationOtp(command: GenerateRegistrationOtpCommand): Promise<OtpGenerationResult> {
     try {
       const { identifier, channel } = this.resolveContact({
-        phoneNumber: command.phoneNumber,
-        email: command.email,
-        phone: command.phoneNumber,
+        phone: command.phone,
         countryCode: command.countryCode,
+        email: command.email,
       });
 
       const otpResult = await this.otpService.generateOtp({
@@ -87,10 +86,9 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
   async generateLoginOtp(command: GenerateLoginOtpCommand): Promise<OtpGenerationResult> {
     try {
       const { identifier, channel } = this.resolveContact({
-        phoneNumber: command.phoneNumber,
-        email: command.email,
-        phone: command.phoneNumber,
+        phone: command.phone,
         countryCode: command.countryCode,
+        email: command.email,
       });
 
       const user = await this.findUserByIdentifier(identifier, channel === 'sms');
@@ -128,10 +126,9 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
   async generatePasswordResetOtp(command: GeneratePasswordResetOtpCommand): Promise<OtpGenerationResult> {
     try {
       const { identifier, channel } = this.resolveContact({
-        phoneNumber: command.phoneNumber,
-        email: command.email,
-        phone: command.phoneNumber,
+        phone: command.phone,
         countryCode: command.countryCode,
+        email: command.email,
       });
 
       const user = await this.findUserByIdentifier(identifier, channel === 'sms');
@@ -173,7 +170,7 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
   async verifyOtp(command: VerifyOtpCommand): Promise<OtpVerificationResult> {
     try {
       const validationResult = await this.otpService.validateOtp({
-        identifier: command.phoneNumber ?? command.email,
+        identifier: command.phone ?? command.email,
         code: command.otp,
         requestId: command.requestId,
         challengeId: command.requestId,
@@ -214,7 +211,6 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
     try {
       const { identifier, channel } = this.resolveContact({
         phone: command.phone,
-        phoneNumber: command.phone,
         countryCode: command.countryCode,
         email: command.email,
       });
@@ -453,13 +449,13 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
         throw new UnauthorizedException('Invalid or expired OTP');
       }
 
-      const identifier = phoneNumber ?? email;
+      const identifier = phone ?? email;
 
       if (!identifier) {
         throw new UnauthorizedException('Missing identifier for login completion');
       }
 
-      const user = await this.findUserByIdentifier(identifier, !!phoneNumber && !email);
+      const user = await this.findUserByIdentifier(identifier, !!phone && !email);
 
       if (!user) {
         throw new UnauthorizedException('User not found');
@@ -523,12 +519,10 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
   }
 
   private resolveContact({
-    phoneNumber,
     phone,
     countryCode,
     email,
   }: {
-    phoneNumber?: string;
     phone?: string;
     countryCode?: string;
     email?: string;
@@ -538,7 +532,7 @@ export class OtpSecurityAdapter extends OtpManagementUseCase {
       return { identifier: emailVo.value, channel: 'email' };
     }
 
-    const rawPhone = phoneNumber ?? phone;
+    const rawPhone = phone;
 
     if (rawPhone && rawPhone.startsWith('+')) {
       const phoneVo = Phone.create(rawPhone);


### PR DESCRIPTION
## Summary
- restore the base auth DTOs to require paired phone and country code inputs instead of accepting standalone E.164 values
- ensure authentication service logic trims and validates split phone data while keeping login and registration guards intact
- align the OTP adapter and accompanying unit tests with the split phone contract used by existing API consumers

## Testing
- npx jest src/modules/auth/application/services/authentication.service.spec.ts *(fails: existing TypeScript errors in src/modules/security/application/services/otp-application.service.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68d960263bac8332af95c5194b48ed79